### PR TITLE
Upgrade ANT to 1.9.5

### DIFF
--- a/cookbooks/localAnt/files/ant.sh
+++ b/cookbooks/localAnt/files/ant.sh
@@ -6,20 +6,20 @@
 echo "installing Ant..."
 #yum -y install ant   # Yum install of ant was not working correctly. outdated & other issues.
 cd /usr/share
-wget --quiet http://mirror.nexcess.net/apache/ant/binaries/apache-ant-1.9.4-bin.tar.gz
-tar xzf apache-ant-1.9.4-bin.tar.gz >/dev/null
-rm -f apache-ant-1.9.4-bin.tar.gz
+wget --quiet http://mirror.nexcess.net/apache/ant/binaries/apache-ant-1.9.5-bin.tar.gz
+tar xzf apache-ant-1.9.5-bin.tar.gz >/dev/null
+rm -f apache-ant-1.9.5-bin.tar.gz
 
 ## tried to put these in /etc/profile.d but 1) didn't work for "non-login shells"
 ## (even shells I was logging in with) and 2) found advice against it
-#echo "export ANT_HOME=\"/usr/share/apache-ant-1.9.4\"" >> ~/.bashrc
-#echo "export PATH=\"/usr/share/apache-ant-1.9.4/bin:\"$PATH" >> ~/.bashrc
+#echo "export ANT_HOME=\"/usr/share/apache-ant-1.9.5\"" >> ~/.bashrc
+#echo "export PATH=\"/usr/share/apache-ant-1.9.5/bin:\"$PATH" >> ~/.bashrc
 
 rm -rf /etc/profile.d/ant.sh
-echo export ANT_HOME=/usr/share/apache-ant-1.9.4\ > /etc/profile.d/ant.sh
-echo export PATH=/usr/share/apache-ant-1.9.4/bin:'$PATH'>>/etc/profile.d/ant.sh
-echo export ANT_HOME=/usr/share/apache-ant-1.9.4\ >> ~/.bashrc
-echo export PATH=/usr/share/apache-ant-1.9.4/bin:'$PATH'>> ~/.bashrc
+echo export ANT_HOME=/usr/share/apache-ant-1.9.5\ > /etc/profile.d/ant.sh
+echo export PATH=/usr/share/apache-ant-1.9.5/bin:'$PATH'>>/etc/profile.d/ant.sh
+echo export ANT_HOME=/usr/share/apache-ant-1.9.5\ >> ~/.bashrc
+echo export PATH=/usr/share/apache-ant-1.9.5/bin:'$PATH'>> ~/.bashrc
 
 chmod +x /etc/profile.d/ant.sh
 cd /etc/profile.d

--- a/cookbooks/localAnt/recipes/default.rb
+++ b/cookbooks/localAnt/recipes/default.rb
@@ -12,22 +12,22 @@
 # downloading and reinstallilng is not that costly
 
 #execute echo "installing Ant"
-remote_file "/opt/apache-ant-1.9.4-bin.tar.gz" do
-    source 'http://mirror.nexcess.net/apache//ant/binaries/apache-ant-1.9.4-bin.tar.gz'
+remote_file "/opt/apache-ant-1.9.5-bin.tar.gz" do
+    source 'http://mirror.nexcess.net/apache//ant/binaries/apache-ant-1.9.5-bin.tar.gz'
 end
 
 bash 'install Ant' do
   cwd '/opt'
   code <<-EOH
-    tar xzf apache-ant-1.9.4-bin.tar.gz
-    rm -f apache-ant-1.9.4-bin.tar.gz
-    echo export ANT_HOME=/opt/apache-ant-1.9.4 > /etc/profile.d/ant.sh  # not idempotent, will continue adding repeated lines
-    echo export ANT_HOME=/usr/share/apache-ant-1.9.4 >> ~/.bashrc       # need to write a simple grep test
+    tar xzf apache-ant-1.9.5-bin.tar.gz
+    rm -f apache-ant-1.9.5-bin.tar.gz
+    echo export ANT_HOME=/opt/apache-ant-1.9.5 > /etc/profile.d/ant.sh  # not idempotent, will continue adding repeated lines
+    echo export ANT_HOME=/usr/share/apache-ant-1.9.5 >> ~/.bashrc       # need to write a simple grep test
     mkdir -p /home/jenkins
-    echo export ANT_HOME=/usr/share/apache-ant-1.9.4 >> /home/jenkins/.bashrc
+    echo export ANT_HOME=/usr/share/apache-ant-1.9.5 >> /home/jenkins/.bashrc
     EOH
 end
 
 link "/usr/local/bin/ant" do
-  to "/opt/apache-ant-1.9.4/bin/ant"
+  to "/opt/apache-ant-1.9.5/bin/ant"
 end


### PR DESCRIPTION
The Brezos server breaks its dependency to Ant as the binary mirrors have upgraded to 1.9.5
