### PR TITLE
Variable-ize ant version

### DIFF
--- a/cookbooks/localAnt/env.sh
+++ b/cookbooks/localAnt/env.sh
@@ -1,0 +1,2 @@
+export ANT_VERSION=apache-ant-1.9.5
+export ANT_MIRROR=http://mirror.nexcess.net/apache/ant/binaries

--- a/cookbooks/localAnt/files/ant.sh
+++ b/cookbooks/localAnt/files/ant.sh
@@ -2,24 +2,27 @@
 #############################    ANT   ########################################
 ###############################################################################
 
+# get the variables from the variable file.
+. ../env.sh
+
 #install ant on ubuntu 14
 echo "installing Ant..."
 #yum -y install ant   # Yum install of ant was not working correctly. outdated & other issues.
 cd /usr/share
-wget --quiet http://mirror.nexcess.net/apache/ant/binaries/apache-ant-1.9.5-bin.tar.gz
-tar xzf apache-ant-1.9.5-bin.tar.gz >/dev/null
-rm -f apache-ant-1.9.5-bin.tar.gz
+wget --quiet $ANT_MIRROR/$ANT_VERSION-bin.tar.gz
+tar xzf $ANT_VERSION-bin.tar.gz >/dev/null
+rm -f $ANT_VERSION-bin.tar.gz
 
 ## tried to put these in /etc/profile.d but 1) didn't work for "non-login shells"
 ## (even shells I was logging in with) and 2) found advice against it
-#echo "export ANT_HOME=\"/usr/share/apache-ant-1.9.5\"" >> ~/.bashrc
-#echo "export PATH=\"/usr/share/apache-ant-1.9.5/bin:\"$PATH" >> ~/.bashrc
+#echo "export ANT_HOME=\"/usr/share/$ANT_VERSION\"" >> ~/.bashrc
+#echo "export PATH=\"/usr/share/$ANT_VERSION/bin:\"$PATH" >> ~/.bashrc
 
 rm -rf /etc/profile.d/ant.sh
-echo export ANT_HOME=/usr/share/apache-ant-1.9.5\ > /etc/profile.d/ant.sh
-echo export PATH=/usr/share/apache-ant-1.9.5/bin:'$PATH'>>/etc/profile.d/ant.sh
-echo export ANT_HOME=/usr/share/apache-ant-1.9.5\ >> ~/.bashrc
-echo export PATH=/usr/share/apache-ant-1.9.5/bin:'$PATH'>> ~/.bashrc
+echo export ANT_HOME=/usr/share/$ANT_VERSION\ > /etc/profile.d/ant.sh
+echo export PATH=/usr/share/$ANT_VERSION/bin:'$PATH'>>/etc/profile.d/ant.sh
+echo export ANT_HOME=/usr/share/$ANT_VERSION\ >> ~/.bashrc
+echo export PATH=/usr/share/$ANT_VERSION/bin:'$PATH'>> ~/.bashrc
 
 chmod +x /etc/profile.d/ant.sh
 cd /etc/profile.d

--- a/cookbooks/localAnt/recipes/default.rb
+++ b/cookbooks/localAnt/recipes/default.rb
@@ -3,7 +3,7 @@
 #############################    ANT  ######################################
 ###############################################################################
 #
-# this is a "wrapper" cookbook. note the presence of an attributes file 
+# this is a "wrapper" cookbook. note the presence of an attributes file
 
 # include_recipe "ant::default"   # couldn't use this, insisted on installing its own Java
 
@@ -11,23 +11,26 @@
 # what if Ant is corrupted? can't test for a perfect install
 # downloading and reinstallilng is not that costly
 
+ENV['ANT_VERSION'] = "apache-ant-1.9.5"
+ENV['ANT_MIRROR'] = "http://mirror.nexcess.net/apache//ant/binaries/"
+
 #execute echo "installing Ant"
-remote_file "/opt/apache-ant-1.9.5-bin.tar.gz" do
-    source 'http://mirror.nexcess.net/apache//ant/binaries/apache-ant-1.9.5-bin.tar.gz'
+remote_file "/opt/" + ENV['ANT_VERSION'] + "-bin.tar.gz" do
+    source ENV['ANT_MIRROR'] + ENV['ANT_VERSION'] + '-bin.tar.gz'
 end
 
 bash 'install Ant' do
   cwd '/opt'
   code <<-EOH
-    tar xzf apache-ant-1.9.5-bin.tar.gz
-    rm -f apache-ant-1.9.5-bin.tar.gz
-    echo export ANT_HOME=/opt/apache-ant-1.9.5 > /etc/profile.d/ant.sh  # not idempotent, will continue adding repeated lines
-    echo export ANT_HOME=/usr/share/apache-ant-1.9.5 >> ~/.bashrc       # need to write a simple grep test
+    tar xzf $ANT_VERSION-bin.tar.gz
+    rm -f $ANT_VERSION-bin.tar.gz
+    echo export ANT_HOME=/opt/$ANT_VERSION > /etc/profile.d/ant.sh  # not idempotent, will continue adding repeated lines
+    echo export ANT_HOME=/usr/share/$ANT_VERSION >> ~/.bashrc       # need to write a simple grep test
     mkdir -p /home/jenkins
-    echo export ANT_HOME=/usr/share/apache-ant-1.9.5 >> /home/jenkins/.bashrc
+    echo export ANT_HOME=/usr/share/$ANT_VERSION >> /home/jenkins/.bashrc
     EOH
 end
 
 link "/usr/local/bin/ant" do
-  to "/opt/apache-ant-1.9.5/bin/ant"
+  to "/opt/" + ENV['ANT_VERSION'] + "/bin/ant"
 end


### PR DESCRIPTION
Addresses #19.

I couldn't figure out a quick way to only have the variables declared in only one place. I have very little experience in Ruby and Chef, so maybe someone else can figure that one out. At any rate, now we have variables declaring the version of ant and the mirror from where to get it (if it ever happens to change).
