### PR TITLE
Update default.rb for localAnt recipe

### DIFF
--- a/cookbooks/localAnt/recipes/default.rb
+++ b/cookbooks/localAnt/recipes/default.rb
@@ -11,7 +11,7 @@
 # what if Ant is corrupted? can't test for a perfect install
 # downloading and reinstallilng is not that costly
 
-ENV['ANT_VERSION'] = "apache-ant-1.9.7"
+ENV['ANT_VERSION'] = "apache-ant-1.9.8"
 # mirrors are flakey
 ENV['ANT_MIRROR'] = "http://apache.mirrors.hoobly.com//ant/binaries/"
 #ENV['ANT_MIRROR'] = "http://mirror.nexcess.net/apache//ant/binaries/"


### PR DESCRIPTION
Since apache-ant-1.9.7 is no longer located on those mirrors, we can choos between downloading from the official archive and previous versions or downloading 1.9.8